### PR TITLE
fix: added missing `import epyqlib.utils.units`

### DIFF
--- a/epyqlib/hildevice.py
+++ b/epyqlib/hildevice.py
@@ -14,6 +14,7 @@ import epyqlib.device
 import epyqlib.nv
 import epyqlib.utils.qt
 import epyqlib.utils.twisted
+import epyqlib.utils.units
 
 
 class FormatVersionError(Exception):


### PR DESCRIPTION
epyqlib.utils.units used in hildevice.py but never imported.
Added `import epyqlib.utils.units` 