### PR TITLE
fix (GT-86): prevent cyclic UnableToPack error messages

### DIFF
--- a/epyqlib/canneo.py
+++ b/epyqlib/canneo.py
@@ -432,6 +432,10 @@ class Signal:
                     )
                 )
 
+            # Check pack_bitstring ahead of time. If this fails with an UnableToPackError exception, then the value
+            # cannot be set and is invalid. Checking here prevents an endless loop of error message dialogs.
+            self.pack_bitstring(value)
+
         return True
 
     def set_value(

--- a/epyqlib/txrx.py
+++ b/epyqlib/txrx.py
@@ -42,7 +42,7 @@ class SignalNode(epyqlib.canneo.Signal, TreeNode):
 
     def set_data(self, data):
         try:
-            self.set_human_value(data)
+            self.set_human_value(data, check_range=True)
         except ValueError:
             raise
         else:


### PR DESCRIPTION
Prevent cyclic UnableToPack error messages when changing parameter values through EPyQ interface.