### PR TITLE
feat (GT-41): add check ID and software hash option

### DIFF
--- a/epyqlib/devicetreeview.py
+++ b/epyqlib/devicetreeview.py
@@ -86,6 +86,7 @@ class DeviceTreeView(QtWidgets.QWidget):
 
         add_device_action = None
         remove_device_action = None
+        check_software_hash_action = None
         change_device_number_action = None
         flash_action = None
         pull_raw_log_action = None


### PR DESCRIPTION
Add check ID and software hash option. Initial idea is to add the option to the right-click menu on the left side tree of devices. Functionality should retrieve the node ID and software hash for a PCAN device and display to the user. See [GT-41](https://epcpower.atlassian.net/browse/GT-41).