### PR TITLE
loosen hash matching for log processing

### DIFF
--- a/epyqlib/variableselectionmodel.py
+++ b/epyqlib/variableselectionmodel.py
@@ -789,7 +789,7 @@ class VariableModel(epyqlib.pyqabstractitemmodel.PyQAbstractItemModel):
             [hash_node] = [
                 n for n in block_header_node.children if n.fields.name == "softwareHash"
             ]
-            log_hash = f'{hash_node.fields.value:07x}'
+            log_hash = f"{hash_node.fields.value:07x}"
             if not hashes_match(self.git_hash, log_hash):
                 if hash_node.fields.value is not None:
                     log_hash = "{:07x}".format(hash_node.fields.value)

--- a/epyqlib/variableselectionmodel.py
+++ b/epyqlib/variableselectionmodel.py
@@ -789,12 +789,13 @@ class VariableModel(epyqlib.pyqabstractitemmodel.PyQAbstractItemModel):
             [hash_node] = [
                 n for n in block_header_node.children if n.fields.name == "softwareHash"
             ]
-            log_hash = f"{hash_node.fields.value:07x}"
+
+            if hash_node.fields.value is not None:
+                log_hash = "{:07x}".format(hash_node.fields.value)
+            else:
+                log_hash = str(hash_node.fields.value)
+
             if not hashes_match(self.git_hash, log_hash):
-                if hash_node.fields.value is not None:
-                    log_hash = "{:07x}".format(hash_node.fields.value)
-                else:
-                    log_hash = str(hash_node.fields.value)
 
                 d = twisted.internet.defer.Deferred()
                 d.errback(

--- a/epyqlib/variableselectionmodel.py
+++ b/epyqlib/variableselectionmodel.py
@@ -796,7 +796,6 @@ class VariableModel(epyqlib.pyqabstractitemmodel.PyQAbstractItemModel):
                 log_hash = str(hash_node.fields.value)
 
             if not hashes_match(self.git_hash, log_hash):
-
                 d = twisted.internet.defer.Deferred()
                 d.errback(
                     Exception(


### PR DESCRIPTION
EPyQ refused to decode a log hash `8669c3f` with a `.out` hash `8669c3ff`.  It seems reasonably likely those are just different truncations of the same SHA.