### PR TITLE
fix (GT-149): update deprecated id_type to is_extended_id

### DIFF
--- a/epyqlib/twisted/cancalibrationprotocol.py
+++ b/epyqlib/twisted/cancalibrationprotocol.py
@@ -547,7 +547,8 @@ class Handler(QObject, twisted.protocols.policies.TimeoutMixin):
 
     def dataReceived(self, msg):
         if not (
-            msg.arbitration_id == self._rx_id and bool(msg.is_extended_id) == self._extended
+            msg.arbitration_id == self._rx_id
+            and bool(msg.is_extended_id) == self._extended
         ):
             return
 

--- a/epyqlib/twisted/cancalibrationprotocol.py
+++ b/epyqlib/twisted/cancalibrationprotocol.py
@@ -547,7 +547,7 @@ class Handler(QObject, twisted.protocols.policies.TimeoutMixin):
 
     def dataReceived(self, msg):
         if not (
-            msg.arbitration_id == self._rx_id and bool(msg.id_type) == self._extended
+            msg.arbitration_id == self._rx_id and bool(msg.is_extended_id) == self._extended
         ):
             return
 
@@ -858,7 +858,7 @@ class Packet:
             code=None,
             timestamp=message.timestamp,
             is_remote_frame=message.is_remote_frame,
-            extended_id=message.id_type,
+            extended_id=message.is_extended_id,
             is_error_frame=message.is_error_frame,
             arbitration_id=message.arbitration_id,
             dlc=message.dlc,

--- a/epyqlib/utils/canlog.py
+++ b/epyqlib/utils/canlog.py
@@ -77,7 +77,7 @@ class Message:
             type=MessageType.Rx,
             id=Id(
                 value=message.arbitration_id,
-                extended=message.id_type,
+                extended=message.is_extended_id,
             ),
             data=bytearray(message.data),
         )


### PR DESCRIPTION
The option "Pull Raw Log..." causes an exception:
```
Traceback (most recent call last):
File "epyqlib\twisted\busproxy.py", line 44, in readEvent
File "epyqlib\twisted\cancalibrationprotocol.py", line 550, in dataReceived
AttributeError: 'Message' object has no attribute 'id_type'
```