### PR TITLE
fix (GT-169): EPyQ crashes after clicking outside combobox on parameters tree

### DIFF
--- a/epyqlib/delegates.py
+++ b/epyqlib/delegates.py
@@ -80,18 +80,34 @@ class CustomCombo(QtWidgets.QComboBox):
         # allow hidePopup to post event to set the value.
         self.view_item_pressed = True
 
+    def sendKeyPress(self, key_to_send):
+        QtCore.QCoreApplication.postEvent(
+            self,
+            QtGui.QKeyEvent(
+                QtCore.QEvent.KeyPress,
+                key_to_send,
+                QtCore.Qt.NoModifier,
+            ),
+        )
+
     def hidePopup(self):
         super().hidePopup()
 
+        # For a mouse click on a view item, send an enter to clear the delegate.
         if self.view_item_pressed:
-            QtCore.QCoreApplication.postEvent(
-                self,
-                QtGui.QKeyEvent(
-                    QtCore.QEvent.KeyPress,
-                    QtCore.Qt.Key_Enter,
-                    QtCore.Qt.NoModifier,
-                ),
-            )
+            self.sendKeyPress(QtCore.Qt.Key_Enter)
+
+    def keyReleaseEvent(self, QKeyEvent):
+        super().keyReleaseEvent(QKeyEvent)
+
+        # For key release, double send the return/enter or escape to clear the delegate.
+        if (
+            QKeyEvent.key() == QtCore.Qt.Key_Return
+            or QKeyEvent.key() == QtCore.Qt.Key_Enter
+        ):
+            self.sendKeyPress(QtCore.Qt.Key_Enter)
+        elif QKeyEvent.key() == QtCore.Qt.Key_Escape:
+            self.sendKeyPress(QtCore.Qt.Key_Escape)
 
 
 class ByFunction(QtWidgets.QStyledItemDelegate):

--- a/epyqlib/delegates.py
+++ b/epyqlib/delegates.py
@@ -70,8 +70,8 @@ class Delegate:
 
 # TODO: CAMPid 374895478431714307074310
 class CustomCombo(QtWidgets.QComboBox):
-    def hidePopup(self):
-        super().hidePopup()
+    def hideEvent(self, QHideEvent):
+        super().hideEvent(QHideEvent)
 
         QtCore.QCoreApplication.postEvent(
             self,

--- a/epyqlib/delegates.py
+++ b/epyqlib/delegates.py
@@ -70,17 +70,28 @@ class Delegate:
 
 # TODO: CAMPid 374895478431714307074310
 class CustomCombo(QtWidgets.QComboBox):
-    def hideEvent(self, QHideEvent):
-        super().hideEvent(QHideEvent)
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.view_item_pressed = False
+        self.view().pressed.connect(self.handleItemPressed)
 
-        QtCore.QCoreApplication.postEvent(
-            self,
-            QtGui.QKeyEvent(
-                QtCore.QEvent.KeyPress,
-                QtCore.Qt.Key_Enter,
-                QtCore.Qt.NoModifier,
-            ),
-        )
+    def handleItemPressed(self):
+        # If an item is selected in the view list,
+        # allow hidePopup to post event to set the value.
+        self.view_item_pressed = True
+
+    def hidePopup(self):
+        super().hidePopup()
+
+        if self.view_item_pressed:
+            QtCore.QCoreApplication.postEvent(
+                self,
+                QtGui.QKeyEvent(
+                    QtCore.QEvent.KeyPress,
+                    QtCore.Qt.Key_Enter,
+                    QtCore.Qt.NoModifier,
+                ),
+            )
 
 
 class ByFunction(QtWidgets.QStyledItemDelegate):


### PR DESCRIPTION
EPyQ crashes on Parameters tab tree, Active column when selecting outside of combobox. See [GT-169](https://epcpower.atlassian.net/browse/GT-169).