### PR TITLE
ci(SC-5421): bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ jobs:
     name: CI
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -77,7 +77,7 @@ jobs:
         run: |
           poetry publish --repository epc-power
       - name: Archive artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: epyq_st
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
           python3 -m pip install poetry==1.5.1
 
           poetry --version
-
           poetry config virtualenvs.in-project true
           poetry config virtualenvs.path .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ defaults:
     shell: bash
 
 env:
-  PYTHON_VERSION: 3.8
+  PYTHON_VERSION: "3.8"
   AWS_REGION: us-east-2
 
 jobs:
@@ -45,6 +45,7 @@ jobs:
           python3 -m pip install poetry==1.5.1
 
           poetry --version
+
           poetry config virtualenvs.in-project true
           poetry config virtualenvs.path .
 


### PR DESCRIPTION
## Summary
Updates the four pinned GitHub Actions in `.github/workflows/ci.yml` to versions that run on Node.js 24, eliminating the Node.js 20 deprecation warnings emitted in CI.

| Action | Old | New |
| --- | --- | --- |
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-python` | `@v5` | `@v6` |
| `aws-actions/configure-aws-credentials` | `@v4` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v7` |

All four targets confirmed `runs.using: node24` upstream and resolve to the latest released patch within each major (v6.0.2 / v6.2.0 / v6.1.1 / v7.0.1 at time of writing).

No `with:` parameter changes required. The breaking changes in these majors do not affect this workflow's usage:
- `configure-aws-credentials@v5` cleaned up invalid-boolean input handling — this workflow only passes string inputs.
- `upload-artifact@v7` converted to ESM and added an opt-in `archive: false` direct-upload mode — this workflow uses the default zipped behaviour.

Part of the org-wide audit in [SC-5421](https://epcpower.atlassian.net/browse/SC-5421). The GitHub-hosted `windows-2022` runner already exceeds the new minimum runner version (v2.327.1) required by these actions, so no runner change is needed.

## Test plan
- [ ] CI run on this branch completes successfully (checkout, setup-python, AWS creds, Poetry install, `black --check`, `pytest`, `poetry build`, artifact upload).
- [ ] No "Node.js 20 is deprecated" warnings appear in any step of the CI log.
- [ ] On a subsequent tag push, the `Publish executable` step (gated by `startsWith(github.ref, 'refs/tags/')`) still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SC-5421]: https://epcpower.atlassian.net/browse/SC-5421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ